### PR TITLE
Updated to MiniPlaceholders 2.0.0

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,5 @@
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 dependencies {

--- a/common/src/main/java/me/sliman4/expressions/Expression.java
+++ b/common/src/main/java/me/sliman4/expressions/Expression.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 
 public interface Expression {
     void register(Expansion.Builder builder);

--- a/common/src/main/java/me/sliman4/expressions/Expressions.java
+++ b/common/src/main/java/me/sliman4/expressions/Expressions.java
@@ -1,27 +1,27 @@
 package me.sliman4.expressions;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.expr.*;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
 public class Expressions {
-    public static void initialize(File dataFolder, InputStream configYml, Platform platform) {
+    public static void initialize(Path dataFolder, InputStream configYml, Platform platform) {
         Configuration config;
         try {
-            if (!dataFolder.exists()) {
-                dataFolder.mkdir();
+            if (Files.notExists(dataFolder)) {
+                Files.createDirectory(dataFolder);
             }
-            File configFile = new File(dataFolder, "config.yml");
-            if (!configFile.exists()) {
-                Files.copy(configYml, configFile.toPath());
+            Path configFile = dataFolder.resolve("config.yml");
+            if (Files.notExists(configFile)) {
+                Files.copy(configYml, configFile);
             }
             Yaml yaml = new Yaml(new Constructor() {
                 @Override
@@ -32,7 +32,7 @@ public class Expressions {
                     return super.getClassForName(name);
                 }
             });
-            config = yaml.loadAs(Files.newInputStream(configFile.toPath()), Configuration.class);
+            config = yaml.loadAs(Files.newInputStream(configFile), Configuration.class);
         } catch (IOException exception) {
             exception.printStackTrace();
             return;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprAdd.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprAdd.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprCeil.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprCeil.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprConcat.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprConcat.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprDiv.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprDiv.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprFloor.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprFloor.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprFormat.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprFormat.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprIf.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprIf.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.minimessage.ParsingException;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprLength.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprLength.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprMax.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprMax.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprMin.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprMin.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprMod.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprMod.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprMul.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprMul.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprNeg.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprNeg.java
@@ -1,6 +1,6 @@
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprPlayer.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprPlayer.java
@@ -1,13 +1,12 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
-import me.dreamerzero.miniplaceholders.api.MiniPlaceholders;
+import io.github.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.MiniPlaceholders;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Platform;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprRandom.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprRandom.java
@@ -1,7 +1,7 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprRound.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprRound.java
@@ -1,7 +1,7 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprSub.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprSub.java
@@ -1,7 +1,7 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprSubstring.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprSubstring.java
@@ -1,7 +1,7 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;
 import net.kyori.adventure.text.Component;

--- a/common/src/main/java/me/sliman4/expressions/expr/ExprUser.java
+++ b/common/src/main/java/me/sliman4/expressions/expr/ExprUser.java
@@ -1,7 +1,7 @@
 
 package me.sliman4.expressions.expr;
 
-import me.dreamerzero.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.Expansion;
 import me.sliman4.expressions.Configuration;
 import me.sliman4.expressions.Expression;
 import me.sliman4.expressions.Utils;

--- a/common/src/test/java/TestUser.java
+++ b/common/src/test/java/TestUser.java
@@ -1,4 +1,4 @@
-import me.dreamerzero.miniplaceholders.api.MiniPlaceholders;
+import io.github.miniplaceholders.api.MiniPlaceholders;
 import me.sliman4.expressions.Configuration;
 import me.sliman4.expressions.Expressions;
 import org.junit.jupiter.api.BeforeEach;

--- a/common/src/test/java/Utils.java
+++ b/common/src/test/java/Utils.java
@@ -1,5 +1,5 @@
-import me.dreamerzero.miniplaceholders.api.Expansion;
-import me.dreamerzero.miniplaceholders.api.MiniPlaceholders;
+import io.github.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.MiniPlaceholders;
 import me.sliman4.expressions.Configuration;
 import me.sliman4.expressions.Expressions;
 import net.kyori.adventure.text.Component;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ junit = "5.8.1"
 krypton = "0.60.3"
 
 [libraries.miniplaceholders]
-group = "com.github.4drian3d"
-name = "MiniPlaceholders"
-version = "1.3.0"
+group = "io.github.miniplaceholders"
+name = "miniplaceholders-api"
+version = "2.0.0"
 
 [libraries.velocity-api]
 group = "com.velocitypowered"

--- a/krypton/build.gradle.kts
+++ b/krypton/build.gradle.kts
@@ -1,7 +1,5 @@
 repositories {
-    mavenCentral()
     maven("https://repo.kryptonmc.org/releases")
-    maven("https://jitpack.io")
 }
 
 dependencies {

--- a/krypton/src/main/java/me/sliman4/expressions/krypton/KryptonPlugin.java
+++ b/krypton/src/main/java/me/sliman4/expressions/krypton/KryptonPlugin.java
@@ -38,6 +38,6 @@ public final class KryptonPlugin {
     public void onProxyInitialize(ServerStartEvent event) {
         logger.info("Starting Expressions Expansion for Krypton");
 
-        Expressions.initialize(dataFolder.toFile(), getClass().getClassLoader().getResourceAsStream("config.yml"), platform);
+        Expressions.initialize(dataFolder, getClass().getClassLoader().getResourceAsStream("config.yml"), platform);
     }
 }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 repositories {
     maven("https://papermc.io/repo/repository/maven-public/")
-    maven("https://jitpack.io")
 }
 
 dependencies {

--- a/paper/src/main/java/me/sliman4/expressions/paper/PaperPlugin.java
+++ b/paper/src/main/java/me/sliman4/expressions/paper/PaperPlugin.java
@@ -9,6 +9,6 @@ public final class PaperPlugin extends JavaPlugin {
     public void onEnable() {
         getLogger().info("Starting Expressions Expansion for Paper");
 
-        Expressions.initialize(getDataFolder(), getResource("config.yml"), new PaperPlatform());
+        Expressions.initialize(getDataFolder().toPath(), getResource("config.yml"), new PaperPlatform());
     }
 }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,6 +1,5 @@
 repositories {
     maven("https://papermc.io/repo/repository/maven-public/")
-    maven("https://jitpack.io")
 }
 
 dependencies {

--- a/velocity/src/main/java/me/sliman4/expressions/velocity/VelocityPlugin.java
+++ b/velocity/src/main/java/me/sliman4/expressions/velocity/VelocityPlugin.java
@@ -39,6 +39,6 @@ public final class VelocityPlugin {
     public void onProxyInitialize(ProxyInitializeEvent event) {
         logger.info("Starting Expressions Expansion for Velocity");
 
-        Expressions.initialize(dataFolder.toFile(), getClass().getClassLoader().getResourceAsStream("config.yml"), platform);
+        Expressions.initialize(dataFolder, getClass().getClassLoader().getResourceAsStream("config.yml"), platform);
     }
 }


### PR DESCRIPTION
What a great Expansion you have here, congratulations.

I recently updated MiniPlaceholders to its [version 2.0.0](https://modrinth.com/plugin/miniplaceholders/version/2.0.0), changing its groupId and publishing the library to Maven Central, here I make the respective changes so that this expansion can work with the latest version of MiniPlaceholders.

In addition, replace the use of File by Path in the configuration load